### PR TITLE
Linux support and printf->qInfo

### DIFF
--- a/hellozmq.pro
+++ b/hellozmq.pro
@@ -34,6 +34,10 @@ macx {
     PRE_TARGETDEPS += /usr/local/Cellar/zeromq/3.2.4/lib/libzmq.a
 }
 
+linux:!android{
+    LIBS += -lzmq
+}
+
 # ZeroMQ ARM
 android {
     LIBS += -L$$PWD/zeromq-android/lib/ -lzmq

--- a/zerosender.cpp
+++ b/zerosender.cpp
@@ -19,7 +19,7 @@ void ZeroSender::send(QString topic, QString msg)
     QByteArray payload = payload_str.toLocal8Bit();
     qDebug() << "payload " << payload << "\n";
 
-    printf("Connecting to the Intercom broker...\n");
+    qInfo() << "Connecting to the Intercom broker...";
     void *requester = zmq_socket (this->context, ZMQ_REQ);
     zmq_connect(requester, "tcp://spirit:5556");
     zmq_send(requester, payload.data(), payload.length(), 0);


### PR DESCRIPTION
Just a little PR that add support for Linux platform, and change the printf() into qInfo() to avoid the need of a 'fflush(0)'.
